### PR TITLE
!2290 积分充值信息去除用户名信息，避免因用户名特殊字符导致支付宝微信无法成功创建订单 * 积分充值信息去除用户名信息，避免因用户名特…

### DIFF
--- a/source/include/spacecp/spacecp_credit_base.php
+++ b/source/include/spacecp/spacecp_credit_base.php
@@ -101,7 +101,7 @@ if($_GET['op'] == 'base') {
 		$return_url = $_G['siteurl'] . 'home.php?mod=spacecp&ac=credit&op=base';
 		$pay_url = payment::create_order(
 			'payment_credit',
-			$_G['setting']['bbname'].' - '.$_G['member']['username'].' - '.lang('forum/misc', 'credit_payment'),
+			$_G['setting']['bbname'].' - '.lang('forum/misc', 'credit_payment'),
 			trim(lang('forum/misc', 'credit_forum_payment') . ' ' . $credits['title'] . ' ' . $amount . ' ' . $credits['unit']),
 			$price * 100,
 			$return_url,


### PR DESCRIPTION
…殊字符导致支付宝微信无法成功创建订单!2290 积分充值信息去除用户名信息，避免因用户名特殊字符导致支付宝微信无法成功创建订单

* 积分充值信息去除用户名信息，避免因用户名特殊字符导致支付宝微信无法成功创建订单